### PR TITLE
Use StringIO in revcomp.cr

### DIFF
--- a/revcomp/revcomp.cr
+++ b/revcomp/revcomp.cr
@@ -4,17 +4,17 @@ def revcomp(seq)
   0.step(stringlen, 60) { |x| puts seq[x...x + 60] }
 end
 
-seq = ""
+seq = StringIO.new
 
 STDIN.each_line do |line|
   if line.starts_with? '>'
     if !seq.empty?
-      revcomp(seq)
-      seq = ""
+      revcomp(seq.to_s)
+      seq.clear
     end
     puts(line)
   else
-    seq += line.chomp
+    seq << line.chomp
   end
 end
-revcomp(seq)
+revcomp(seq.to_s)


### PR DESCRIPTION
Hi!

In Crystal Strings are immutable. If you want to build a String you can use `String#+` but that's slow because many intermediary strings will be created. Instead, the recommended way is to use a `StringIO`. So, I guess this is not "cheating" the benchmark.

Additionally, STDIN is not buffered so `each_line` is slow. Instead, you can do:

``` crystal
BufferedIO.new(STDIN).each_line do |line|
  ...
end
```

That brings speed and memory closer to that of C and Ruby. But, maybe this last thing is cheating. I think the best thing to do is either to make STDIN buffered by default (we would wrap it with a BufferedIO) or to document this too very well.

I'm pretty satisfied with the other benchmarks. Crystal might not be the fastest, but it has a good balance between readable/writeable code and efficiency :-)
