### PR TITLE
Use monotonic time for measuring wall-clock time

### DIFF
--- a/xtime.rb
+++ b/xtime.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 def mem(pid); `ps p #{pid} -o rss`.split.last.to_i; end
-t = Time.now
+t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 pid = Process.spawn(*ARGV.to_a)
 mm = 0
 
@@ -14,5 +14,5 @@ Thread.new do
 end
 
 Process.waitall
-STDERR.puts "== %.2fs, %.1fMb ==" % [Time.now - t, mm / 1024.0]
-
+t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+STDERR.puts "== %.2fs, %.1fMb ==" % [t1 - t0, mm / 1024.0]


### PR DESCRIPTION
I recently used this lib to benchmark the performance of Crystal 0.30.0 against Crystal 0.34.0. I noticed it uses `Time.now` to measure the elapsed time. This PR changes it it so were are using Ruby's monotonic time. More info here: https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/

Thanks!